### PR TITLE
Add #to_h to models; make #inspect dump all attributes

### DIFF
--- a/lib/calendly/models/model_utils.rb
+++ b/lib/calendly/models/model_utils.rb
@@ -13,6 +13,7 @@ module Calendly
     # @param [Calendly::Client] the api client.
     def initialize(attrs = nil, client = nil)
       @client = client
+      @data = attrs || {}
       set_attributes attrs
     end
 
@@ -47,13 +48,19 @@ module Calendly
     # @since 0.0.1
     def inspect
       att_info = []
-      inspect_attributes.each do |att|
+
+      # Print out all the attributes, showing the key ones (defined in inspect_attributes) first
+      (inspect_attributes + @data.keys).uniq.each do |att|
         next unless respond_to? att
 
         att_info << "#{att}=#{send(att).inspect}"
       end
-      att_info << '..'
+
       "\#<#{self.class}:#{object_id} #{att_info.join(', ')}>"
+    end
+
+    def to_h
+      @data
     end
 
     module ClassMethods


### PR DESCRIPTION
Port of https://github.com/koshilife/calendly-api-ruby-client/pull/64

This PR aims to improve the debugging experience and general UX by making it easier to see what's going on.

First, adding a `#to_h` method on Calendly models, so you can easily see the raw data as a hash (helpful for generating API payloads, for instance).

Second, increasing the usefulness of the `#inspect` method by making it print _all_ attributes. Previously, this was what you'd get:

```rb
> pp event
=> #<Calendly::Event:27980 uuid="c79022c3-45a1-46e9-96bd-8fab44908b48", name="Testing/Staging ", status="active", ..>
```

This was super frustrating, as the truncation was hardcoded, and there was no way to see all the attributes at once.

Now you get:

```rb
> pp event
=> #<Calendly::Event:27980 uuid="c79022c3-45a1-46e9-96bd-8fab44908b48", name="Testing/Staging ", status="active", created_at=2023-06-29 09:23:34.003966 UTC, end_time=2023-06-30 08:00:00 UTC, event_guests=[], event_memberships=[#<Calendly::User:27900 uuid="0c5d2a34-4113-4cff-9b34-7db34c8dc324", name=nil, slug=nil, email=nil, uri="https://api.calendly.com/users/0c5d2a34-4113-4cff-9b34-7db34c8dc324">], event_type=#<Calendly::EventType:27920 uuid="bc2baf5b-9aae-42b1-8438-6d3079da163c", name=nil, type=nil, slug=nil, active=nil, kind=nil, scheduling_url=nil, uri="https://api.calendly.com/event_types/bc2baf5b-9aae-42b1-8438-6d3079da163c", ..>, invitees_counter=#<Calendly::InviteesCounter:27940 active=1, limit=1, total=1>, location=#<Calendly::Location:27960 type="custom", status=nil, location=nil>, start_time=2023-06-30 07:30:00 UTC, updated_at=2023-06-29 09:23:34.923187 UTC, uri="https://api.calendly.com/scheduled_events/c79022c3-45a1-46e9-96bd-8fab44908b48">
```

Much longer, but much more helpful, as intended for `#inspect`.

