### PR TITLE
Bump oauth

### DIFF
--- a/calendly.gemspec
+++ b/calendly.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'faraday', '>= 1.0.0', '< 3.0.0'
-  spec.add_runtime_dependency 'oauth2', '~> 1.4', '>= 1.4.4'
+  spec.add_runtime_dependency 'oauth2', '~> 2.0'
 
   spec.add_development_dependency 'activesupport'
   spec.add_development_dependency 'bundler'

--- a/lib/calendly/api_error.rb
+++ b/lib/calendly/api_error.rb
@@ -17,11 +17,12 @@ module Calendly
     # @return [OAuth2::Error, JSON::ParserError]
     attr_reader :cause_exception
 
-    def initialize(response, cause_exception, message: nil)
+    def initialize(response, cause_exception, message: nil, status: nil)
       @response = response
       @cause_exception = cause_exception
       @message = message
       set_attributes_from_response
+      @status ||= status
       @message ||= cause_exception.message if cause_exception
       super @message
     end

--- a/lib/calendly/client.rb
+++ b/lib/calendly/client.rb
@@ -845,6 +845,8 @@ module Calendly
       res = access_token.request method, path, params: params, body: body
       debug_log "Response status:#{res.status}, body:#{res.body.dup&.force_encoding(Encoding::UTF_8)}"
       parse_as_json res
+    rescue JSON::ParserError => e
+      raise ApiError.new nil, e, message: "Invalid response received: #{e.message}", status: 400
     rescue OAuth2::Error => e
       res = e.response.response
       raise ApiError.new res, e
@@ -878,7 +880,8 @@ module Calendly
       {
         site: API_HOST,
         authorize_url: "#{AUTH_API_HOST}/oauth/authorize",
-        token_url: "#{AUTH_API_HOST}/oauth/token"
+        token_url: "#{AUTH_API_HOST}/oauth/token",
+        auth_scheme: :request_body
       }
     end
 

--- a/test/assert_helper.rb
+++ b/test/assert_helper.rb
@@ -1392,7 +1392,7 @@ module AssertHelper
     e = assert_raises Calendly::ApiError do
       proc.call
     end
-    assert_equal ex_body, e.response.body
+    assert_equal ex_body, e.response.body if ex_body
     assert_equal ex_status, e.status
     assert_equal ex_title, e.title if ex_title
     assert_equal ex_message, e.message if ex_message

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -1510,7 +1510,7 @@ module Calendly
       proc_error = proc do
         @client.user user_id
       end
-      assert_api_error proc_error, 400, res_body
+      assert_api_error proc_error, 400, nil, nil, "Invalid response received: unexpected token at '#{res_body}'"
     end
 
     #


### PR DESCRIPTION
This bumps the oauth gem to v2 since v1.4 is end of life and has been for a couple years.

Theres some minor changes because oauth v2
* no longer rescues parsing errors
* changed a default setting for auth_scheme

Tested this on a live environment and it seems to be working!